### PR TITLE
Simplification de la fonction `genererDegreDepuisString`

### DIFF
--- a/ressources/scripts/outils.js
+++ b/ressources/scripts/outils.js
@@ -72,8 +72,6 @@ function genererDegreDepuisString(string) {
         hash += string.charCodeAt(i);
     }
 
-    hash = Math.abs(hash);
-
     const scaledNumber = hash % 361;
 
     return scaledNumber;


### PR DESCRIPTION
# Description de la Pull Request

## Description brève des modifications

Cette pull request simplifie la fonction `genererDegreDepuisString` en supprimant le calcul de la valeur absolue du hash.

## Détail des modifications

La modification consiste à retirer l'appel à `Math.abs()` sur la variable `hash` dans la fonction `genererDegreDepuisString`.

## Objectif des modifications

En retirant le calcul de la valeur absolue du hash, nous simplifions le code et améliorons sa lisibilité sans compromettre la fonctionnalité. La fonction `charCodeAt` retourne des valeurs comprises entre 0 et 65535 (UTF-16), donc le calcul de la valeur absolue n'est pas nécessaire.

## Étapes de vérification

1. Assurez-vous que la fonction `genererDegreDepuisString` génère toujours des degrés dans la plage de 0 à 360.
2. Vérifiez que les tests unitaires associés à cette fonction passent avec succès après la modification.

