### PR TITLE
Sécurisation de l'API

### DIFF
--- a/documentation/Script_procedures.sql
+++ b/documentation/Script_procedures.sql
@@ -1024,8 +1024,24 @@ END
 -- Utiliser pour supprimer un cocktail dans mon profil
 DROP PROCEDURE IF EXISTS SupprimerCocktail;
 
-CREATE PROCEDURE SupprimerCocktail(IN var_id_cocktail INT)
+CREATE PROCEDURE SupprimerCocktail(IN var_id_cocktail INT, IN var_id_utilisateur INT) suppCocktail:
 BEGIN
+    -- Vérifier si l'utilisateur a le droit de supprimer le cocktail
+    IF NOT EXISTS (
+        SELECT id_cocktail
+        FROM Cocktail
+        WHERE id_cocktail = var_id_cocktail
+        AND id_utilisateur = var_id_utilisateur
+    ) AND NOT EXISTS (
+        SELECT id_utilisateur
+        FROM utilisateur
+        WHERE id_utilisateur = var_id_utilisateur
+        AND privilege = 1
+    ) THEN
+        SELECT 'Erreur: Vous n\'avez pas les droits pour supprimer ce cocktail' AS success;
+        LEAVE suppCocktail;
+    END IF;
+
     DELETE FROM cocktail_liked
     WHERE id_cocktail = var_id_cocktail;
     CALL SupprimerCommentaireDeCocktail(var_id_cocktail);
@@ -1046,8 +1062,24 @@ END
 -- Permet de supprimer un commentaire
 DROP PROCEDURE IF EXISTS SupprimerCommentaire;
 
-CREATE PROCEDURE SupprimerCommentaire(IN var_id_commentaire INT)
+CREATE PROCEDURE SupprimerCommentaire(IN var_id_commentaire INT, IN var_id_utilisateur INT) suppCommentaire:
 BEGIN
+    -- Vérifier si l'utilisateur a le droit de supprimer le commentaire
+    IF NOT EXISTS (
+        SELECT id_commentaire
+        FROM Commentaire
+        WHERE id_commentaire = var_id_commentaire
+        AND id_utilisateur = var_id_utilisateur
+    ) AND NOT EXISTS (
+        SELECT id_utilisateur
+        FROM utilisateur
+        WHERE id_utilisateur = var_id_utilisateur
+        AND privilege = 1
+    ) THEN
+        SELECT 'Erreur: Vous n\'avez pas les droits pour supprimer ce commentaire' AS success;
+        LEAVE suppCommentaire;
+    END IF;
+
     DELETE FROM commentaire_liked
     WHERE id_commentaire = var_id_commentaire;
     DELETE FROM commentaire

--- a/ressources/api/ajouterCocktail.php
+++ b/ressources/api/ajouterCocktail.php
@@ -25,6 +25,7 @@ header('Content-Type: application/json');
 require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/fonctionAPIphp/paramJSONvalide.php';
 require_once __DIR__ . '/fonctionAPIphp/usernameToId.php';
+require_once __DIR__ . '/fonctionAPIphp/authorisationAPI.php';
 
 $conn = connexionBD();
 
@@ -40,6 +41,7 @@ $nomAlcoolPrincipale = paramJSONvalide($donnee, 'nomAlcoolPrincipale');
 $username = paramJSONvalide($donnee, 'username');
 $image = paramJSONvalide($donnee, 'image');
 
+userAccesResssource($username);
 $userId = usernameToId($username, $conn);
 
 // Démarre une transaction pour ajouter le cocktail afin d'éviter les incohérences dans la base de données

--- a/ressources/api/ajouterCommentaire.php
+++ b/ressources/api/ajouterCommentaire.php
@@ -23,6 +23,7 @@ require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/fonctionAPIphp/usernameToId.php';
 require_once __DIR__ . '/../classephp/Commentaire_Classe.php';
 require_once __DIR__ . '/fonctionAPIphp/paramJSONvalide.php';
+require_once __DIR__ . '/fonctionAPIphp/authorisationAPI.php';
 
 $conn = connexionBD();
 
@@ -33,6 +34,7 @@ $username = paramJSONvalide($donnees, 'username');
 $idCocktail = paramJSONvalide($donnees, 'id_cocktail');
 $contenuCommentaire = paramJSONvalide($donnees, 'commentaire');
 
+userAccesResssource($username);
 $userId = usernameToId($username, $conn);
 
 try {

--- a/ressources/api/ajouterIngredientMonBar.php
+++ b/ressources/api/ajouterIngredientMonBar.php
@@ -22,6 +22,7 @@ header('Content-Type: application/json');
 require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/fonctionAPIphp/usernameToId.php';
 require_once __DIR__ . '/fonctionAPIphp/paramJSONvalide.php';
+require_once __DIR__ . '/fonctionAPIphp/authorisationAPI.php';
 
 $conn = connexionBD();
 
@@ -32,6 +33,7 @@ $donnee = json_decode(file_get_contents('php://input'), true);
 $nomIngredient = paramJSONvalide($donnee, 'nomIngredient');
 $username = paramJSONvalide($donnee, 'username');
 
+userAccesResssource($username);
 $userId = usernameToId($username, $conn);
 
 try {

--- a/ressources/api/config.php
+++ b/ressources/api/config.php
@@ -14,9 +14,11 @@
  * @author Maxim Dmitriev, Vianney Veremme, Yani Amellal
  */
 
+
 function connexionBD(): ?mysqli
 {
     require_once(__DIR__ . '/../../../configDonne.php');
+
     try {
         // Créer la connexion à la base de données directement
         $conn = new mysqli($DB_HOST, $DB_USER, $DB_PASSWORD, $DB_NAME);

--- a/ressources/api/connexion.php
+++ b/ressources/api/connexion.php
@@ -78,6 +78,12 @@ $response = array(
 );
 
 if ($success) {
+    if (!isset($src) || $src != 'web') {
+        require(__DIR__ . '/../../../configDonne.php');
+
+        $token = hash_hmac('sha256', $nom, $cle);
+        $response['token'] = $token;
+    }
     $response["username"] = $nom;
 }
 

--- a/ressources/api/dislikeCocktail.php
+++ b/ressources/api/dislikeCocktail.php
@@ -22,6 +22,7 @@ header('Content-Type: application/json');
 require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/fonctionAPIphp/usernameToId.php';
 require_once __DIR__ . '/fonctionAPIphp/paramJSONvalide.php';
+require_once __DIR__ . '/fonctionAPIphp/authorisationAPI.php';
 
 $conn = connexionBD();
 
@@ -30,6 +31,8 @@ $donnees = json_decode(file_get_contents('php://input'), true);
 // Vérifie si les paramètres sont présents
 $username = paramJSONvalide($donnees, 'username');
 $id_cocktail = paramJSONvalide($donnees, 'id_cocktail');
+
+userAccesResssource($username);
 $userId = usernameToId($username, $conn);
 
 try {

--- a/ressources/api/dislikeCommentaire.php
+++ b/ressources/api/dislikeCommentaire.php
@@ -22,6 +22,7 @@ header('Content-Type: application/json');
 require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/fonctionAPIphp/usernameToId.php';
 require_once __DIR__ . '/fonctionAPIphp/paramJSONvalide.php';
+require_once __DIR__ . '/fonctionAPIphp/authorisationAPI.php';
 
 $conn = connexionBD();
 
@@ -30,6 +31,8 @@ $donnees = json_decode(file_get_contents('php://input'), true);
 // Vérifie si les paramètres sont présents et les échappe
 $username = paramJSONvalide($donnees, 'username');
 $id_commentaire = paramJSONvalide($donnees, 'id_commentaire');
+
+userAccesResssource($username);
 $userId = usernameToId($username, $conn);
 
 

--- a/ressources/api/enleverIngredientMonBar.php
+++ b/ressources/api/enleverIngredientMonBar.php
@@ -22,6 +22,7 @@ header('Content-Type: application/json');
 require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/fonctionAPIphp/usernameToId.php';
 require_once __DIR__ . '/fonctionAPIphp/paramJSONvalide.php';
+require_once __DIR__ . '/fonctionAPIphp/authorisationAPI.php';
 
 $conn = connexionBD();
 
@@ -30,6 +31,8 @@ $donnees = json_decode(file_get_contents("php://input"), true);
 
 $nomIngredient = paramJSONvalide($donnees, 'nomIngredient');
 $username = paramJSONvalide($donnees, 'username');
+
+userAccesResssource($username);
 $userId = usernameToId($username, $conn);
 
 try {

--- a/ressources/api/fonctionAPIphp/authorisationAPI.php
+++ b/ressources/api/fonctionAPIphp/authorisationAPI.php
@@ -12,14 +12,11 @@
  */
 function userAccesResssource($usernameRequete)
 {
-
-    if (session_status() == PHP_SESSION_NONE) {
-        session_start();
-    }
-
-    if (isset($_SESSION['username'])) {
-        $username = $_SESSION['username'];
-        if ($username == $usernameRequete) {
+    if (isset($_SERVER['HTTP_AUTHORIZATION'])) {
+        include(__DIR__ . '/../../../../configDonne.php');
+        $token = $_SERVER['HTTP_AUTHORIZATION'];
+        $usernameRequeteHash = hash_hmac('sha256', $usernameRequete, $cle);
+        if (hash_equals($token, $usernameRequeteHash)) {
             return true;
         } else {
             http_response_code(403);
@@ -27,8 +24,23 @@ function userAccesResssource($usernameRequete)
             exit();
         }
     } else {
-        http_response_code(401);
-        echo json_encode(array("message" => "Vous n'êtes pas connecté."));
-        exit();
+        if (session_status() == PHP_SESSION_NONE) {
+            session_start();
+        }
+
+        if (isset($_SESSION['username'])) {
+            $username = $_SESSION['username'];
+            if ($username == $usernameRequete) {
+                return true;
+            } else {
+                http_response_code(403);
+                echo json_encode(array("message" => "Vous n'avez pas accès à cette ressource."));
+                exit();
+            }
+        } else {
+            http_response_code(401);
+            echo json_encode(array("message" => "Vous n'êtes pas connecté."));
+            exit();
+        }
     }
 }

--- a/ressources/api/fonctionAPIphp/authorisationAPI.php
+++ b/ressources/api/fonctionAPIphp/authorisationAPI.php
@@ -5,6 +5,9 @@
  * Fonction userAccesResssource
  *
  * Cette fonction vérifie si l'utilisateur à accès à la ressource demandée.
+ * Si un token est présent dans le header, il est comparé avec le hash du nom d'utilisateur.
+ * Si un token n'est pas présent, la fonction vérifie si l'utilisateur possède une session active et
+ * si le nom d'utilisateur correspond à celui de la requête.
  *
  * @param string $usernameRequete
  *
@@ -12,9 +15,10 @@
  */
 function userAccesResssource($usernameRequete)
 {
-    if (isset($_SERVER['HTTP_AUTHORIZATION'])) {
+
+    if (isset($_SERVER['HTTP_AUTH'])) {
         include(__DIR__ . '/../../../../configDonne.php');
-        $token = $_SERVER['HTTP_AUTHORIZATION'];
+        $token = $_SERVER['HTTP_AUTH'];
         $usernameRequeteHash = hash_hmac('sha256', $usernameRequete, $cle);
         if (hash_equals($token, $usernameRequeteHash)) {
             return true;

--- a/ressources/api/getUserCocktails.php
+++ b/ressources/api/getUserCocktails.php
@@ -22,6 +22,7 @@ header("Content-Type: application/json");
 require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/fonctionAPIphp/InfoAffichageCocktail.php';
 require_once __DIR__ . '/fonctionAPIphp/usernameToId.php';
+require_once __DIR__ . '/fonctionAPIphp/authorisationAPI.php';
 
 // Connexion à la base de données
 $conn = connexionBD();
@@ -31,8 +32,12 @@ $cocktails = [];
 //Liste d'id de cocktails
 $id_cocktail = [];
 
+userAccesResssource($username);
+
 // Transforme le nom d'utilisateur en id
 $id_user = usernameToId($username, $conn);
+
+
 
 try {
     //Demande les cocktails fait par l'utilisateur

--- a/ressources/api/getUserInfo.php
+++ b/ressources/api/getUserInfo.php
@@ -23,6 +23,7 @@ header("Content-Type: application/json");
 require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/../classephp/Utilisateur_Classe.php';
 require_once __DIR__ . '/fonctionAPIphp/usernameToId.php';
+require_once __DIR__ . '/fonctionAPIphp/authorisationAPI.php';
 
 $conn = connexionBD();
 
@@ -34,6 +35,7 @@ if (isset($_GET['user'])) {
     exit();
 }
 
+userAccesResssource($username);
 $userId = usernameToId($username, $conn);
 
 try {

--- a/ressources/api/getUserIngredients.php
+++ b/ressources/api/getUserIngredients.php
@@ -22,12 +22,15 @@
 header('Content-Type: application/json');
 require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/fonctionAPIphp/usernameToId.php';
+require_once __DIR__ . '/fonctionAPIphp/authorisationAPI.php';
 
 // Connexion à la base de données
 $conn = connexionBD();
 
 //Liste des noms d'ingrédients(Alcool et Ingredient)
 $ingredients = [];
+
+userAccesResssource($username);
 
 // Transforme le nom d'utilisateur en id
 $id_user = usernameToId($username, $conn);

--- a/ressources/api/getUserRecommandations.php
+++ b/ressources/api/getUserRecommandations.php
@@ -30,6 +30,7 @@ header("Content-Type: application/json");
 require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/fonctionAPIphp/InfoAffichageCocktail.php';
 require_once __DIR__ . '/fonctionAPIphp/usernameToId.php';
+require_once __DIR__ . '/fonctionAPIphp/authorisationAPI.php';
 
 $idCocktails = [];
 $cocktails = [];
@@ -37,6 +38,8 @@ $ingManquants = [];
 
 // Connexion à la base de données
 $conn = connexionBD();
+
+userAccesResssource($username);
 
 $userID = usernameToId($username, $conn);
 

--- a/ressources/api/likeCocktail.php
+++ b/ressources/api/likeCocktail.php
@@ -22,12 +22,15 @@ header('Content-Type: application/json');
 require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/fonctionAPIphp/usernameToId.php';
 require_once __DIR__ . '/fonctionAPIphp/paramJSONvalide.php';
+require_once __DIR__ . '/fonctionAPIphp/authorisationAPI.php';
 
 $conn = connexionBD();
 
 $donnees = json_decode(file_get_contents('php://input'), true);
 $id_cocktail = paramJSONvalide($donnees, 'id_cocktail');
 $username = paramJSONvalide($donnees, 'username');
+
+userAccesResssource($username);
 $userId = usernameToId($username, $conn);
 
 try {

--- a/ressources/api/likeCommentaire.php
+++ b/ressources/api/likeCommentaire.php
@@ -22,12 +22,15 @@ header('Content-Type: application/json');
 require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/fonctionAPIphp/usernameToId.php';
 require_once __DIR__ . '/fonctionAPIphp/paramJSONvalide.php';
+require_once __DIR__ . '/fonctionAPIphp/authorisationAPI.php';
 
 $conn = connexionBD();
 
 $donnees = json_decode(file_get_contents('php://input'), true);
 $id_commentaire = paramJSONvalide($donnees, 'id_commentaire');
 $username = paramJSONvalide($donnees, 'username');
+
+userAccesResssource($username);
 $userId = usernameToId($username, $conn);
 
 try {

--- a/ressources/api/modifierImageProfil.php
+++ b/ressources/api/modifierImageProfil.php
@@ -20,6 +20,7 @@ header("Content-Type: application/json");
 require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/fonctionAPIphp/usernameToId.php';
 require_once __DIR__ . '/fonctionAPIphp/paramJSONvalide.php';
+require_once __DIR__ . '/fonctionAPIphp/authorisationAPI.php';
 
 $conn = connexionBD();
 
@@ -27,6 +28,7 @@ $donnee = json_decode(file_get_contents('php://input'), true);
 
 $username = paramJSONvalide($donnee, 'username');
 
+userAccesResssource($username);
 $id_user = usernameToId($username, $conn);
 
 try {

--- a/ressources/api/modifierMotDePasse.php
+++ b/ressources/api/modifierMotDePasse.php
@@ -22,6 +22,7 @@ header('Content-Type: application/json');
 require_once(__DIR__ . "/config.php");
 require_once(__DIR__ . "/fonctionAPIphp/paramJSONvalide.php");
 require_once(__DIR__ . "/fonctionAPIphp/usernameToId.php");
+require_once(__DIR__ . "/fonctionAPIphp/authorisationAPI.php");
 
 
 $donnee = json_decode(file_get_contents('php://input'), true);
@@ -32,6 +33,8 @@ $mdp = paramJSONvalide($donnee, 'mdp');
 $nouveauMdp = paramJSONvalide($donnee, 'nouveauMdp');
 $confNouveauMdp = paramJSONvalide($donnee, "confNouveauMdp");
 $nom = paramJSONvalide($donnee, 'nom');
+
+userAccesResssource($nom);
 
 
 // Valider le nouveau mot de passe

--- a/ressources/api/rechercheUserRecommandations.php
+++ b/ressources/api/rechercheUserRecommandations.php
@@ -27,6 +27,7 @@ header('Content-Type: application/json');
 require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/fonctionAPIphp/usernameToId.php';
 require_once __DIR__ . '/fonctionAPIphp/InfoAffichageCocktail.php';
+require_once __DIR__ . '/fonctionAPIphp/authorisationAPI.php';
 
 $conn = connexionBD();
 
@@ -34,6 +35,7 @@ $cocktails = []; //Liste d'objets Cocktail
 $idCocktails = []; //Liste d'id de cocktails
 $ingManquants = []; //Liste d'ingrédients manquants
 
+userAccesResssource($username);
 $userId = usernameToId($username, $conn);
 
 try {

--- a/ressources/api/supprimerCocktail.php
+++ b/ressources/api/supprimerCocktail.php
@@ -11,21 +11,29 @@
  *
  * @param JSON : id_cocktail
  *
+ * @param JSON : username
+ *
  * @return JSON 1 si le cocktail a été supprimé, 0 sinon
  */
 
 header("content-type: application/json");
 require_once(__DIR__ . "/config.php");
 require_once(__DIR__ . "/fonctionAPIphp/paramJSONvalide.php");
+require_once(__DIR__ . "/fonctionAPIphp/authorisationAPI.php");
+require_once(__DIR__ . "/fonctionAPIphp/usernameToId.php");
 
 $conn = connexionBD();
 
 $donnees = json_decode(file_get_contents('php://input'), true);
 $id_cocktail = paramJSONvalide($donnees, 'id_cocktail');
+$username = paramJSONvalide($donnees, 'username');
+
+userAccesResssource($username);
+$userId = usernameToId($username, $conn);
 
 try {
-    $requete_preparee = $conn->prepare("CALL SupprimerCocktail(?)");
-    $requete_preparee->bind_param("i", $id_cocktail);
+    $requete_preparee = $conn->prepare("CALL SupprimerCocktail(?, ?)");
+    $requete_preparee->bind_param("ii", $id_cocktail, $userId);
     $requete_preparee->execute();
     $resultat = $requete_preparee->get_result();
     $requete_preparee->close();

--- a/ressources/api/supprimerCommentaire.php
+++ b/ressources/api/supprimerCommentaire.php
@@ -15,15 +15,21 @@
 header("content-type: application/json");
 require_once(__DIR__ . "/config.php");
 require_once(__DIR__ . "/fonctionAPIphp/paramJSONvalide.php");
+require_once(__DIR__ . "/fonctionAPIphp/authorisationAPI.php");
+require_once(__DIR__ . "/fonctionAPIphp/usernameToId.php");
 
 $conn = connexionBD();
 
 $donnee = json_decode(file_get_contents("php://input"), true);
 $id_commentaire = paramJSONvalide($donnee, "id_commentaire");
+$username = paramJSONvalide($donnee, "username");
+
+userAccesResssource($username);
+$userID = usernameToId($username, $conn);
 
 try {
-    $requete_preparee = $conn->prepare("CALL SupprimerCommentaire(?)");
-    $requete_preparee->bind_param("i", $id_commentaire);
+    $requete_preparee = $conn->prepare("CALL SupprimerCommentaire(?, ?)");
+    $requete_preparee->bind_param("ii", $id_commentaire, $userID);
     $requete_preparee->execute();
     $resultat = $requete_preparee->get_result();
     $requete_preparee->close();

--- a/ressources/api/supprimerProfile.php
+++ b/ressources/api/supprimerProfile.php
@@ -16,11 +16,14 @@ header("content-type: application/json");
 require_once(__DIR__ . "/config.php");
 require_once(__DIR__ . "/fonctionAPIphp/paramJSONvalide.php");
 require_once(__DIR__ . "/fonctionAPIphp/usernameToId.php");
+require_once(__DIR__ . "/fonctionAPIphp/authorisationAPI.php");
 
 $conn = connexionBD();
 
 $donnee = json_decode(file_get_contents("php://input"), true);
 $username = paramJSONvalide($donnee, "username");
+
+userAccesResssource($username);
 $userID = usernameToId($username, $conn);
 
 try {

--- a/ressources/scripts/connexionWeb.php
+++ b/ressources/scripts/connexionWeb.php
@@ -2,7 +2,7 @@
 session_start();
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-
+    $src = 'web';
 
     require_once __DIR__ . "/../api/connexion.php";
 


### PR DESCRIPTION
Toutes les requêtes à l'API qui sont en lien avec une ressource propre à un utilisateur sont maintenant protégées, soit par l'utilisation de session en web ou de token en mobile. Il y a 2 chemins lors de la connexion, /authentification pour le web qui active une session et /api/users/authentification qui renvoie un token. Ce token doit être présent dans le header de toutes les requêtes faites par le mobile sous la forme de (Auth : sda34124kn421nkl4214124lk421).

* Il va falloir rajouter une clé secrete dans le fichier configDonne qui est a l'extérieur du root