### PR TITLE
Utilisation box-shadow pour les icones oranges

### DIFF
--- a/ressources/styles/connexion.css
+++ b/ressources/styles/connexion.css
@@ -69,7 +69,7 @@ input:focus {
 }
 
 #form-connexion>button:hover {
-    box-shadow: var(--orange-neon-box);
+    filter: drop-shadow(0 0 25px var(--palette-button-border-color));
     text-shadow: var(--neon-text-pink);
     background-color: var(--palette-background-color);
 }

--- a/ressources/styles/index.css
+++ b/ressources/styles/index.css
@@ -89,7 +89,7 @@ nav {
 }
 
 #radio-cocktail:checked {
-    box-shadow: var(--orange-neon-box);
+    filter: drop-shadow(0 0 25px var(--palette-button-border-color));
     text-shadow: var(--neon-text-pink);
     text-wrap: nowrap;
 }
@@ -114,7 +114,7 @@ nav {
 }
 
 #deux-boutons button:hover {
-    box-shadow: var(--orange-neon-box);
+    filter: drop-shadow(0 0 25px var(--palette-button-border-color));
 }
 
 #deux-boutons button img {
@@ -183,7 +183,7 @@ aside#contenant-boutons-fixes a img {
     font-size: x-large;
     background-color: var(--palette-background-secondary-color);
     color: var(--palette-lighttext-color);
-    box-shadow: var(--orange-neon-box);
+    filter: drop-shadow(0 0 25px var(--palette-button-border-color));
 }
 
 #galerie {
@@ -214,7 +214,7 @@ aside#contenant-boutons-fixes a img {
 }
 
 #profil-utilisateur:hover {
-    box-shadow: var(--orange-neon-box);
+    filter: drop-shadow(0 0 25px var(--palette-button-border-color));
 }
 
 .profile-pic {
@@ -279,7 +279,7 @@ aside#contenant-boutons-fixes a img {
 #bouton-deconnexion:hover,
 #bouton-connexion:hover {
     background-color: var(--palette-button-color-hover);
-    box-shadow: var(--orange-neon-box);
+    filter: drop-shadow(0 0 25px var(--palette-button-border-color));
 }
 
 @media (prefers-color-scheme: dark) {

--- a/ressources/styles/inscription.css
+++ b/ressources/styles/inscription.css
@@ -81,7 +81,7 @@ h1 {
 }
 
 #soumettre:hover {
-    box-shadow: var(--orange-neon-box);
+    filter: drop-shadow(0 0 25px var(--palette-button-border-color));
     text-shadow: var(--neon-text-pink);
     background-color: var(--palette-background-color);
 }

--- a/ressources/styles/modale.css
+++ b/ressources/styles/modale.css
@@ -142,7 +142,7 @@
 }
 
 #commenter>form button:hover {
-    box-shadow: var(--orange-neon-box);
+    filter: drop-shadow(0 0 25px var(--palette-button-border-color));
     text-shadow: var(--neon-text-pink);
 }
 

--- a/ressources/styles/monbar.css
+++ b/ressources/styles/monbar.css
@@ -57,7 +57,7 @@ main {
 }
 
 #profil-utilisateur:hover {
-    box-shadow: var(--orange-neon-box);
+    filter: drop-shadow(0 0 25px var(--palette-button-border-color));
 }
 
 .profile-pic {
@@ -169,7 +169,7 @@ header h1 {
 .ingredient-item:hover {
     color: var(--palette-lighttext-color);
     background-color: var(--palette-button-color-hover);
-    box-shadow: var(--orange-neon-box);
+    filter: drop-shadow(0 0 25px var(--palette-button-border-color));
     text-shadow: var(--neon-text-pink)
 }
 
@@ -258,7 +258,7 @@ header h1 {
 }
 
 #deux-boutons button:hover {
-    box-shadow: var(--orange-neon-box);
+    filter: drop-shadow(0 0 25px var(--palette-button-border-color));
 }
 
 #deux-boutons button img {
@@ -308,7 +308,7 @@ header h1 {
 #bouton-galerie:hover,
 #bouton-deconnexion:hover {
     background-color: var(--palette-button-color-hover);
-    box-shadow: var(--orange-neon-box);
+    filter: drop-shadow(0 0 25px var(--palette-button-border-color));
 }
 
 .ingredients-selectionne {
@@ -325,7 +325,7 @@ header h1 {
 .ingredients-selectionne:hover {
     color: var(--palette-lighttext-color);
     background-color: var(--palette-button-color-hover);
-    box-shadow: var(--orange-neon-box);
+    filter: drop-shadow(0 0 25px var(--palette-button-border-color));
     text-shadow: var(--neon-text-pink);
 }
 

--- a/ressources/styles/publication.css
+++ b/ressources/styles/publication.css
@@ -154,7 +154,7 @@ label {
 
 #ajouter-ingredient:hover,
 #enlever-ingredient:hover {
-    box-shadow: var(--orange-neon-box);
+    filter: drop-shadow(0 0 25px var(--palette-button-border-color));
 }
 
 #ajouter-ingredient>.btn-icon,

--- a/ressources/styles/userprofile.css
+++ b/ressources/styles/userprofile.css
@@ -160,7 +160,7 @@ h3 {
 #info-btn:hover,
 #cocktail-btn:hover,
 #support-btn:hover {
-    box-shadow: var(--orange-neon-box);
+    filter: drop-shadow(0 0 25px var(--palette-button-border-color));
     text-shadow: var(--neon-text-pink);
 }
 
@@ -195,7 +195,7 @@ h3 {
 #submit-btn:hover {
     background-color: var(--palette-background-color);
     color: var(--palette-lighttext-color);
-    box-shadow: var(--orange-neon-box);
+    filter: drop-shadow(0 0 25px var(--palette-button-border-color));
     border: var(--palette-button-border-color);
     cursor: pointer
 }


### PR DESCRIPTION
Avant:
![image](https://github.com/Cocktail-Wizard/Cocktail_Wizard/assets/10519369/905eb55a-a419-44a7-9a7a-564dbce0a4cf) ![image](https://github.com/Cocktail-Wizard/Cocktail_Wizard/assets/10519369/c2aec94c-0954-4890-807c-474ecb3f7e2e)


Après:
![image](https://github.com/Cocktail-Wizard/Cocktail_Wizard/assets/10519369/9b4a3415-df38-49d5-80a4-fd880ab8866a) ![image](https://github.com/Cocktail-Wizard/Cocktail_Wizard/assets/10519369/9d7e8b9c-cc00-4920-9604-8d5008907320)

